### PR TITLE
Handle timestamps more gracefully

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -2,7 +2,7 @@
   (:require [clojure.tools.build.api :as b]))
 
 (def lib 'com.treasuryprime/sked)
-(def version "1.0.1")
+(def version "1.0.2")
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))


### PR DESCRIPTION
Makes life easier for clients who don't use `java.time.Instant`.
